### PR TITLE
Added PowerPlatform GCC links

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -172,7 +172,7 @@ aderror,,Login error lookup,,Azure Active Directory,https://login.microsoftonlin
 l,,Login page,,Azure Active Directory,https://login.microsoftonline.com/
 introubleshoot,,Troubleshooting,,Intune,https://endpoint.microsoft.com/#view/Microsoft_Intune_DeviceSettings/SupportMenu/~/troubleshooting
 pbigcc.cmd.ms,powerbi|gcc,Power BI GCC,,Microsoft 365,https://app.powerbigov.us/
-ppgcc.cmd.ms,ppa|power|gcc,Power Platform,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
+ppgcc.cmd.ms,ppa|power|gcc,Power Platform GCC,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
 pappsgcc.cmd.ms,apps|power|gcc,PowerApps GCC,,Microsoft 365,https://make.gov.powerapps.us/
 pautogcc.cmd.ms,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
 ppagesgcc.cmd.ms,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/

--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -174,5 +174,5 @@ introubleshoot,,Troubleshooting,,Intune,https://endpoint.microsoft.com/#view/Mic
 pbigcc,powerbi|gcc,Power BI GCC,,Microsoft 365,https://app.powerbigov.us/
 ppgcc,ppa|power|gcc,Power Platform GCC,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
 pappsgcc,apps|power|gcc,PowerApps GCC,,Microsoft 365,https://make.gov.powerapps.us/
-pautogcc,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
-ppagesgcc,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/
+pflowgcc,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
+ppagegcc,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/

--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -171,3 +171,8 @@ azprice,price,Azure Price Calculator,,Azure,https://azure.microsoft.com/pricing/
 aderror,,Login error lookup,,Azure Active Directory,https://login.microsoftonline.com/error
 l,,Login page,,Azure Active Directory,https://login.microsoftonline.com/
 introubleshoot,,Troubleshooting,,Intune,https://endpoint.microsoft.com/#view/Microsoft_Intune_DeviceSettings/SupportMenu/~/troubleshooting
+pbigcc.cmd.ms,powerbi|gcc,Power BI GCC,,Microsoft 365,https://app.powerbigov.us/
+ppgcc.cmd.ms,ppa|power|gcc,Power Platform,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
+pappsgcc.cmd.ms,apps|power|gcc,PowerApps GCC,,Microsoft 365,https://make.gov.powerapps.us/
+pautogcc.cmd.ms,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
+ppagesgcc.cmd.ms,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/

--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -171,8 +171,8 @@ azprice,price,Azure Price Calculator,,Azure,https://azure.microsoft.com/pricing/
 aderror,,Login error lookup,,Azure Active Directory,https://login.microsoftonline.com/error
 l,,Login page,,Azure Active Directory,https://login.microsoftonline.com/
 introubleshoot,,Troubleshooting,,Intune,https://endpoint.microsoft.com/#view/Microsoft_Intune_DeviceSettings/SupportMenu/~/troubleshooting
-pbigcc.cmd.ms,powerbi|gcc,Power BI GCC,,Microsoft 365,https://app.powerbigov.us/
-ppgcc.cmd.ms,ppa|power|gcc,Power Platform GCC,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
-pappsgcc.cmd.ms,apps|power|gcc,PowerApps GCC,,Microsoft 365,https://make.gov.powerapps.us/
-pautogcc.cmd.ms,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
-ppagesgcc.cmd.ms,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/
+pbigcc,powerbi|gcc,Power BI GCC,,Microsoft 365,https://app.powerbigov.us/
+ppgcc,ppa|power|gcc,Power Platform GCC,,Microsoft 365,https://gcc.admin.powerplatform.microsoft.us
+pappsgcc,apps|power|gcc,PowerApps GCC,,Microsoft 365,https://make.gov.powerapps.us/
+pautogcc,automate|flow|power|gcc,PowerAutomate GCC,,Microsoft 365,https://make.gov.powerautomate.us/
+ppagesgcc,pages|power|gcc,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us/


### PR DESCRIPTION
In this PR, i have added GCC links for Power BI, Power Platform Admin center, PowerApps Makers portal, PowerAutomate and Power BI. I have also shortened GCC PowerApps links to _papps_ instead of _powerapps_ . 