### PR TITLE
Added powerbi, powerplatform, powerapps, power automate and power pages for GCC High and DoD

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -185,3 +185,13 @@ ppagegcc,,PowerPages GCC,,Microsoft 365,https://make.gov.powerpages.microsoft.us
 adidp,,Azure AD Identity Protection,,Azure Active Directory,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/Overview
 azlogic,,Azure Logic Apps,,Azure,https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Logic%2Fworkflows
 azpim,,Azure Resources Privileged Identity Management,,Azure,https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/CommonMenuBlade/~/azurerbac
+pbigcch,,Power BI GCC High,,Microsoft 365,https://app.high.powerbigov.us/
+ppgcch,,Power Platform GCC High,,Microsoft 365,https://high.admin.powerplatform.microsoft.us/
+pappsgcch,,PowerApps GCC High,,Microsoft 365,https://make.high.powerapps.us/
+pflowgcch,,PowerAutomate GCC High,,Microsoft 365,https://high.flow.microsoft.us/
+ppagegcch,,PowerPages GCC High,,Microsoft 365,https://make.high.powerpages.microsoft.us/
+pbidod,,Power BI DoD,,Microsoft 365,https://app.mil.powerbigov.us/
+ppdod,,Power Platform DoD,,Microsoft 365,https://admin.appsplatform.us/
+pappsdod,,PowerApps DoD,,Microsoft 365,https://make.apps.appsplatform.us/
+pflowdod,,PowerAutomate DoD,,Microsoft 365,https://flow.appsplatform.us/
+ppagedod,,PowerPages DoD,,Microsoft 365,https://make.powerpages.microsoft.appsplatform.us/


### PR DESCRIPTION
In this PR,
- added powerbi, powerplatform, powerapps, power automate and power paeges link for GCC High and DoD

The information was obtained from here:
Power Platform links: https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government
Power BI link: https://learn.microsoft.com/en-us/power-bi/enterprise/service-govus-overview
Power Pages link: https://powerpages.microsoft.com/en-us/blog/microsoft-power-pages-is-generally-available-in-us-government-clouds/

This should address some part of this request #73 