### PR TITLE
feat: add Windows 365 portal

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -207,3 +207,4 @@ aka,,AkaSearch,,General,https://akaSearch.net
 lighthouse,,Lighthouse,,Microsoft 365,https://lighthouse.microsoft.com/
 adlaps,,Local Administrator Password Recovery,LAPS,Azure Active Directory,https://entra.microsoft.com/#view/Microsoft_AAD_Devices/DevicesMenuBlade/~/LocalAdminPassword/menuId/Overview
 inwdu,,Driver updates for Windows 10,,Intune,https://intune.microsoft.com/#view/Microsoft_Intune_DeviceSettings/DevicesMenu/~/windowsDriverUpdate?#view/Microsoft_Intune_DeviceSettings/DevicesMenu/~/windows10UpdateRings?=
+win365,cloudpc,Windows 365,Windows 365 Cloud PC,Microsoft 365,https://windows365.microsoft.com/


### PR DESCRIPTION
This is a suggestion to add Windows 365 portal. (also known as Cloud PC). The abbreviation and alias are suggestions, but feel free to adjust.