### PR TITLE
Fix link for enpimz.cmd.ms (PIM for Azure resources)

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -64,7 +64,7 @@ enmfaunblock,admfaunblock,MFA unblock,,Entra,https://entra.microsoft.com/#view/M
 enpim,adpim|pim,PIM,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_PIMCommon/CommonMenuBlade/~/quickStart
 enpimr,adpimr,PIM for Roles,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/aadmigratedroles?
 enpimg,adpimg,PIM for Groups,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/aadgroup?
-enpimz,adpimz|adpimaz,PIM for Azure resources,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_PIMCommon/CommonMenuBlade/~/azurerbac?
+enpimz,adpimz|adpimaz,PIM for Azure resources,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac?
 enar,adreviews|adar,Access reviews,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_ERM/DashboardBlade/~/Controls
 enroles,adroles,Roles and administrators,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/RolesManagementMenuBlade/~/AllRoles
 enpa,adpa,Protected actions,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/RolesManagementMenuBlade/~/ProtectedActions


### PR DESCRIPTION
The blade reference for the "PIM for Azure resources" short link https://enpimz.cmd.ms has to be corrected from `CommonMenuBlade` to `ActivationMenuBlade` to work properly.