### PR TITLE
Add "User settings" alias

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -94,6 +94,7 @@ enctas,adctas|adxtap|enxtap,Cross-tenant access settings,external,Entra,https://
 enadfslog,adadfslog,ADFS services,,Entra,https://entra.microsoft.com/#view/Microsoft_Azure_ADHybridHealth/AadHealthMenuBlade/~/AdfsServicesList
 enauth,adauth,Authentication methods,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods
 enconsent,adconsent,Consent and permissions,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings
+enusrsettings,adusrsettings,User settings,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings
 enpumfa,enlegacymfa|adlegacymfa,Legacy MFA,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/MultifactorAuthenticationConfig.ReactView/tabId/users
 enlicense,adlicense,Licenses,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/LicensesMenuBlade/~/Products
 ennew,,What's new,,Entra,https://entra.microsoft.com/#blade/Microsoft_AAD_IAM/ChangeManagementHubList.ReactView?


### PR DESCRIPTION
The new name for this blade is "User settings" so I suggest to add it.

I hesitated between adding a new command, which I did, or just adding an alias to the existing "enconsent" command which is just above. I decided to add one because "user settings" is too far from "consent", and I preferred not to rename the existing one to avoid regression.
I let you double-check which you prefer.