### PR TITLE
Replaced compliance portal URLs with purview portal alternatives

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -34,40 +34,40 @@ mail,outlook,Outlook,,Microsoft 365,https://outlook.office365.com/mail/
 mailg,outlookg,Outlook for GCC High,,Microsoft 365,https://outlook.office365.us/mail/
 puudg,purviewudg|purview,Purview Unified Data Governance,Azure Purview portal,Azure,https://web.purview.azure.com
 puudgg,purviewudgg|purviewg,Purview Unified Data Governance for GCC High,Azure Purview portal,Azure,https://web.purview.azure.us
-puperms,,Purview Permissions manager,,Microsoft 365,https://compliance.microsoft.com/permissions
+puperms,,Purview Permissions manager,,Microsoft 365,https://purview.microsoft.com/settings/purviewpermissions
 pupermsg,,Purview Permissions manager for GCC High,,Microsoft 365,https://compliance.microsoft.us/permissions
-pucmgr,decm,Purview Compliance manager,Microsoft Compliance Manager,Microsoft 365,https://compliance.microsoft.com/compliancemanager
+pucmgr,decm,Purview Compliance manager,Microsoft Compliance Manager,Microsoft 365,https://purview.microsoft.com/compliancemanager
 pucmgrg,decmg,Purview Compliance manager for GCC High,Microsoft Compliance Manager,Microsoft 365,https://compliance.microsoft.us/compliancemanager
 pucloudgov,,Purview App Governance,,Microsoft 365,https://compliance.microsoft.com/cloudapps/app-governance
-puaudit,,Purview Audit,Microsoft 365 Advanced Audit,Microsoft 365,https://compliance.microsoft.com/auditlogsearch
+puaudit,,Purview Audit,Microsoft 365 Advanced Audit,Microsoft 365,https://purview.microsoft.com/audit/auditsearch
 puauditg,,Purview Audit for GCC High,Microsoft 365 Advanced Audit,Microsoft 365,https://compliance.microsoft.com/auditlogsearch
-pucomms,,Purview Communication Compliance,Microsoft 365 Communication Compliance,Microsoft 365,https://compliance.microsoft.com/supervisoryreview
+pucomms,,Purview Communication Compliance,Microsoft 365 Communication Compliance,Microsoft 365,https://purview.microsoft.com/cc
 pucommsg,,Purview Communication Compliance for GCC High,Microsoft 365 Communication Compliance,Microsoft 365,https://compliance.microsoft.us/supervisoryreview
-pudlp,dlp,Purview Data Loss Prevention,Microsoft Endpoint DLP,Microsoft 365,https://compliance.microsoft.com/datalossprevention
+pudlp,dlp,Purview Data Loss Prevention,Microsoft Endpoint DLP,Microsoft 365,https://purview.microsoft.com/datalossprevention
 pudlpg,dlpg,Purview Data Loss Prevention for GCC High,Microsoft Endpoint DLP,Microsoft 365,https://compliance.microsoft.us/datalossprevention
-puedisc,ediscovery,Purview eDiscovery,Office 365 Advanced eDiscovery,Microsoft 365,https://compliance.microsoft.com/advancedediscovery
+puedisc,ediscovery,Purview eDiscovery,Office 365 Advanced eDiscovery,Microsoft 365,https://purview.microsoft.com/ediscovery/advancedediscovery
 puediscg,ediscoveryg,Purview eDiscovery for GCC High,Office 365 Advanced eDiscovery,Microsoft 365,https://compliance.microsoft.us/advancedediscovery
-pudlm,,Purview Data Lifecycle Management,Microsoft Information Governance,Microsoft 365,https://compliance.microsoft.com/informationgovernance
+pudlm,,Purview Data Lifecycle Management,Microsoft Information Governance,Microsoft 365,https://purview.microsoft.com/datalifecyclemanagement
 pudlmg,,Purview Data Lifecycle Management for GCC High,Microsoft Information Governance,Microsoft 365,https://compliance.microsoft.us/informationgovernance
-purecmon,,Purview Records Management,Records Management in Microsoft 365,Microsoft 365,https://compliance.microsoft.com/recordsmanagement
+purecmon,,Purview Records Management,Records Management in Microsoft 365,Microsoft 365,https://purview.microsoft.com/recordsmanagement
 purecmong,,Purview Records Management for GCC High,Records Management in Microsoft 365,Microsoft 365,https://compliance.microsoft.us/recordsmanagement
-puinfoprot,,Purview Information Protection,Microsoft Information Protection,Microsoft 365,https://compliance.microsoft.com/informationprotection
+puinfoprot,,Purview Information Protection,Microsoft Information Protection,Microsoft 365,https://purview.microsoft.com/informationprotection
 puinfoprotg,,Purview Information Protection for GCC High,Microsoft Information Protection,Microsoft 365,https://compliance.microsoft.us/informationprotection
-puirm,,Purview Insider Risk Management,Microsoft 365 Insider Risk Management,Microsoft 365,https://compliance.microsoft.com/insiderriskmgmt
+puirm,,Purview Insider Risk Management,Microsoft 365 Insider Risk Management,Microsoft 365,https://purview.microsoft.com/insiderriskmgmt
 puirmg,,Purview Insider Risk Management for GCC High,Microsoft 365 Insider Risk Management,Microsoft 365,https://compliance.microsoft.us/insiderriskmgmt
-puprivaprm,,Purview Priva Privacy Risk Management,,Microsoft 365,https://compliance.microsoft.com/privacymgmtoverview
+puprivaprm,,Purview Priva Privacy Risk Management,,Microsoft 365,https://purview.microsoft.com/priva/prm
 puprivaprmg,,Purview Priva Privacy Risk Management for GCC High,,Microsoft 365,https://compliance.microsoft.us/privacymgmtoverview
-puprivasrr,,Purview Priva Subject Rights Requests,,Microsoft 365,https://compliance.microsoft.com/privacymgmtsrm
+puprivasrr,,Purview Priva Subject Rights Requests,,Microsoft 365,https://purview.microsoft.com/priva/dsr/governance/main/privacydsr/privacy/overview
 puprivasrrg,,Purview Priva Subject Rights Requests for GCC High,,Microsoft 365,https://compliance.microsoft.us/privacymgmtsrm
-puactexp,,Purview Activity Explorer,,Microsoft 365,https://compliance.microsoft.com/dataclassification/activityexplorer
+puactexp,,Purview Activity Explorer,,Microsoft 365,https://purview.microsoft.com/informationprotection/dataclassification/activityexplorer
 puactexpg,,Purview Activity Explorer for GCC High,,Microsoft 365,https://compliance.microsoft.us/dataclassification/activityexplorer
-pucontentse,,Purview Content Search,,Microsoft 365,https://compliance.microsoft.com/contentsearchv2
+pucontentse,,Purview Content Search,,Microsoft 365,https://purview.microsoft.com/ediscovery/contentsearchv2
 pucontentseg,,Purview Content Search for GCC High,,Microsoft 365,https://compliance.microsoft.us/contentsearchv2
-pucontentex,,Purview Content Explorer,,Microsoft 365,https://compliance.microsoft.com/dataclassification/contentexplorer
+pucontentex,,Purview Content Explorer,,Microsoft 365,https://purview.microsoft.com/informationprotection/dataclassification/contentexplorer
 pucontentexg,,Purview Content Explorer for GCC High,,Microsoft 365,https://compliance.microsoft.us/dataclassification/contentexplorer
-pusit,,Purview Sensitive Info Types,,Microsoft 365,https://compliance.microsoft.com/dataclassificationclassifiers?viewid=sensitiveinfotypes
+pusit,,Purview Sensitive Info Types,,Microsoft 365,https://purview.microsoft.com/cc/dataclassification/multicloudsensitiveinfotypes
 pusitg,,Purview Sensitive Info Types for GCC High,,Microsoft 365,https://compliance.microsoft.us/dataclassificationclassifiers?viewid=sensitiveinfotypes
-puclassifiers,,Purview Data Classification,,Microsoft 365,https://compliance.microsoft.com/dataclassificationclassifiers
+puclassifiers,,Purview Data Classification,,Microsoft 365,https://purview.microsoft.com/cc/dataclassification/multicloudsensitiveinfotypes
 puclassifiersg,,Purview Data Classification for GCC High,,Microsoft 365,https://compliance.microsoft.us/dataclassificationclassifiers
 deincidents,deinc,Incidents,,Defender,https://security.microsoft.com/incidents
 deincidentsg,deincg,Incidents for GCC High,,Defender,https://security.microsoft.us/incidents


### PR DESCRIPTION
Now that compliance portal is retired, I switched as many URLs as I could from Compliance to the new Purview alternatives.

Couple notes to be aware of:

1. Not sure if this same retirement applies to GCC High and I can't test this, so I didn't touch those.
2. `pucloudgov` - Could not find where this lives now - my guess is it's now part of Defender for Cloud Apps, but that has no real "Cloud App Governance" section I could find, so I left this as-is also.
3. `puclassifiers` - There is no real top-level Data Classification page in the new portal, only the sub-pages for SIT, Trainable Classifiers, and EDM, so I pointed this one to the SIT sub-page. This makes it a duplicate of `pusit`, so not sure if it's better suited as just being an alias of that, but have kept these separate for now.
4. Speaking of `puclassifiers` and `pusit`, these also appear to exist under the Records management solution (`https://purview.microsoft.com/recordsmanagement/dataclassification/multicloudsensitiveinfotypes`) as well as the Communication Compliance solution. My guess is you can make changes in either and they point to the same place under the hood, but for now I've pointed it to the URL of the CC version.
5. `pucontentse` and `puedisc` - I have left these pointing to the Classic eDiscovery pages in the Purview portal rather than the newest ones as the newest ones are still in preview.