### PR TITLE
Update commands.csv

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -97,7 +97,8 @@ enauth,adauth,Authentication methods,,Entra,https://entra.microsoft.com/#view/Mi
 enconsent,adconsent,Consent and permissions,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ConsentPoliciesMenuBlade/~/UserSettings
 enusrsettings,enusersettings,User settings,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserManagementMenuBlade/~/UserSettings/menuId/UserSettings
 enpumfa,enlegacymfa|adlegacymfa,Legacy MFA,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/MultifactorAuthenticationConfig.ReactView/tabId/users
-enlicense,adlicense,Licenses,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/LicensesMenuBlade/~/Products
+enlicense,,Licenses,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/LicensesMenuBlade/~/Products
+adlicense,,Licenses,,Microsoft 365,https://admin.cloud.microsoft/?#/licenses
 ennew,,What's new,,Entra,https://entra.microsoft.com/#blade/Microsoft_AAD_IAM/ChangeManagementHubList.ReactView?
 ensign,adsign|adlogs|enlogs,Sign-in logs,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/SignInEventsV3Blade/timeRangeType/last24hours/showApplicationSignIns~/true
 enmfaunblock,admfaunblock,MFA unblock,,Entra,https://entra.microsoft.com/#view/Microsoft_AAD_IAM/MultifactorAuthenticationMenuBlade/~/BlockedUsers/fromProviders~/false


### PR DESCRIPTION
Licenses management page was migrated over to https://admin.cloud.microsoft/?#/licenses causing enlicense.cmd.ms to no longer be an effective shortcut.