### PR TITLE
Added M365 Admin Centre 'Active Users'

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -352,3 +352,4 @@ demdeonboard,,Onboarding,,Defender,https://security.microsoft.com/securitysettin
 demdeoffboard,,Offboarding,,Defender,https://security.microsoft.com/securitysettings/endpoints/offboarding,
 cps,,Copilot Studio,,Power Platform,https://copilotstudio.microsoft.com,
 cpsg,,Copilot Studio GCC,,Power Platform,https://gcc.powerva.microsoft.us,
+adminusers,,users|Active Users,,Microsoft 365 Admin,Microsoft 365,,https://admin.microsoft.com/#/users


### PR DESCRIPTION
Added M365 Admin Center 'Active Users'. Useful for when you need to access the users blade from the M365 Admin Center directly.