### PR TITLE
Add notify-yako workflow

### DIFF
--- a/.github/workflows/notify-yako.yml
+++ b/.github/workflows/notify-yako.yml
@@ -1,0 +1,22 @@
+name: notify-yako
+
+# Fire a repository_dispatch at merill/yako on every push to the default branch
+# so getyako.com rebuilds immediately instead of waiting for the hourly poll.
+on:
+    push:
+        branches: [main, master]
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Dispatch to merill/yako
+              env:
+                  TOKEN: ${{ secrets.YAKO_DISPATCH_TOKEN }}
+              run: |
+                  curl -sf -X POST \
+                      -H "Accept: application/vnd.github+json" \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      -H "X-GitHub-Api-Version: 2022-11-28" \
+                      https://api.github.com/repos/merill/yako/dispatches \
+                      -d '{"event_type":"upstream-cmd-changed"}'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/notify-yako.yml` which fires a `repository_dispatch`
at `merill/yako` on every push to the default branch.

This lets [getyako.com](https://getyako.com) rebuild its cached copy of
`commands.csv` within seconds of a merge here, instead of waiting for the
hourly poll in yako's `sync-upstream.yml`.

## Requirements

- Repository secret `YAKO_DISPATCH_TOKEN` (fine-grained PAT scoped to
  `merill/yako` with **Contents: Read** and **Actions: Read and write**).
  Already configured.

## Dispatch event type

`upstream-cmd-changed` — matches the handler in
`merill/yako/.github/workflows/sync-upstream.yml`.