### PR TITLE
Update azdns alias

### DIFF
--- a/website/config/commands.csv
+++ b/website/config/commands.csv
@@ -282,7 +282,7 @@ deastrep,,Attack Simulation Training Reports,,Defender,https://security.microsof
 mshealth,,Microsoft 365 Service health,,Microsoft 365,https://admin.microsoft.com/#/servicehealth,
 cp,,Copilot,,Microsoft 365,https://copilot.microsoft.com,
 cpd,,Copilot Dashboard,,Microsoft 365,https://analysis.insights.cloud.microsoft,
-azdns,,DNS zones,,Azure,https://portal.azure.com/#browse/Microsoft.Network%2FdnsZones,
+azdns,,DNS zones,,Azure,https://portal.azure.com/#view/HubsExtension/AssetMenuBlade/~/PublicDnsZones/assetName/NetworkFoundation/extensionName/Microsoft_Azure_Network,
 xdrthreathunt,th|threathunt,Threat Hunting,,XDR Sentinel,https://security.microsoft.com/sentinel/hunting,
 xdranalytics,,Analytic Rules,,XDR Sentinel,https://security.microsoft.com/sentinel/analytics,
 xdrwatchlist,watchlist,Sentinel Watchlist,,XDR Sentinel,https://security.microsoft.com/sentinel/watchlist,


### PR DESCRIPTION
Updated the Azure portal link for the azdns alias as the previous link no longer works correctly.